### PR TITLE
Added loading second part of bootloader

### DIFF
--- a/BIOS/biosboot.s
+++ b/BIOS/biosboot.s
@@ -5,20 +5,41 @@
 ; So to go further we need to set stack, GDT and laod more segments from memory.
 ; What we have is BIOS interrupts that we can use.
 
+SECOND_LOAD_ADDR equ 0x9000
+
 section .bios1
 ; We are in real mode.
 bits 16
 
+; BIOS stores in DL drive that it was booted from.
+mov [DRIVE] , DL
+
 ; Print test message
-mov BX , TEST_MSG
+mov BX , TEST_INIT_MSG
 call bprint
 
+mov AH , 0x2 ; Read from disk.
+mov AL , 0x1 ; Read one sector.
+mov CH , 0x0 ; Cylinder 0.
+mov CL , 0x2 ; Start reading from sector 2.
+mov DH , 0x0 ; Head 0.
+mov DL , [DRIVE] ; Read from same drive as boot.
+mov BX , SECOND_LOAD_ADDR ; Load data to this position.
+int 0x13
+
+mov BX , TEST_LOAD_MSG
+call bprint
+
+jmp bios2_code
 ; Infinity loop.
 jmp $
 
 
-TEST_MSG:
-	db "Initial code loaded" , 0x0
+TEST_INIT_MSG:
+	db "Initial code loaded", 0xA, 0xD, 0x0
+
+DRIVE:
+	db 0x0
 
 ; This copies code from files here.
 %include "bmodules/bprint.s"
@@ -27,3 +48,23 @@ times 510 - ($-$$) db 0x0
 
 ; This is magic word that tells BIOS that this is bootable sector.
 dw 0xAA55
+
+section .bios2
+bits 16
+
+; Code located in second sector.
+bios2_code:
+	mov bx , TEST_B2CODE_MSG
+	call bprint
+
+	; Ininity loop
+	jmp $
+	
+TEST_LOAD_MSG:
+	db "Second code loaded", 0xA, 0xD, 0x0
+
+TEST_B2CODE_MSG:
+	db "Called from bios2", 0xA, 0xD, 0x0
+
+; Make sure its 512 byte long.
+times 512 - ($-$$) db 0x0

--- a/Linkers/linker_BIOS.ld
+++ b/Linkers/linker_BIOS.ld
@@ -2,11 +2,17 @@
 OUTPUT_FORMAT("binary")
 
 SECTIONS {
-	# Here bios loads our code
-	. = 0x7C00;
-	.text : 
+	# This memory must be precisely defined.
+	# First sector will be loaded at 0x7C00 and in binary will start at the begining. 
+	.bios_sec1 0x7C00 : AT(0x0)
 	{
-		*(.bios1)	
+		*(.bios1)
+	}
+	
+	# Second sector will be loaded at 0x9000 and in binary will start from 512byte offset (size of first sec)
+	.bios_sec2 0x9000 : AT(0x200)
+	{
+		*(.bios2)
 	}
 
 }


### PR DESCRIPTION
Initially BIOS loads only 512 bytes and bootloader probably will be longer so we must load other parts using BIOS before we move to the long mode (or even protected mode).